### PR TITLE
📃 fix: 修复 Clarity ID 在 Github Action 中的引入

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,7 @@ jobs:
           echo VITE_LEANCLOUD_ID: ${{ secrets.VITE_LEANCLOUD_ID }} >> .env
           echo VITE_LEANCLOUD_KEY: ${{ secrets.VITE_LEANCLOUD_KEY }} >> .env
           echo VITE_LEANCLOUD_SERVER: ${{ secrets.VITE_LEANCLOUD_SERVER }} >> .env
+          echo VITE_CLARITY_ID: ${{ secrets.VITE_CLARITY_ID }} >> .env
       
       - name: Build
         run: pnpm run build


### PR DESCRIPTION
在 .env.sample 文件内的 VITE_CLARITY_ID 似乎未在 deploy.yml 内配置