### PR TITLE
ci: 添加 GitHub Actions 工作流以自动发布标签版本

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,40 @@
+name: tag release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: List files
+        run: ls -R
+
+      - name: Package files
+        run: |
+          tar -czvf ethereal.tar.gz --exclude=".github" --exclude="dist" .
+
+
+  release:
+    runs-on: ubuntu-latest
+    needs: package
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: .
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            ethereal.tar.gz


### PR DESCRIPTION
添加 tag-release.yml 工作流文件，用于在推送 v* 标签时自动打包文件并创建 GitHub 发布