### PR TITLE
ci(workflow): 添加上传构建产物的步骤并排除.git目录

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -20,8 +20,13 @@ jobs:
 
       - name: Package files
         run: |
-          tar -czvf ethereal.tar.gz --exclude=".github" --exclude="dist" .
+          tar -czvf ethereal.tar.gz --exclude=".github" --exclude="dist" --exclude=".git" .
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ethereal
+          path: ethereal.tar.gz
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
在打包步骤中排除.git目录以避免包含不必要的文件
添加上传构建产物的步骤以便后续使用